### PR TITLE
Use ZWESECUR for SAF

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,6 @@ node('ibm-jenkins-slave-dind') {
     "scripts/temp-fixes-after-started.sh",
     "scripts/install-zowe.sh",
     "scripts/install-config.sh",
-    "scripts/install-xmem-server.sh",
     "scripts/uninstall-zowe.sh",
     "scripts/install-SMPE-PAX.sh",
     "scripts/uninstall-SMPE-PAX.sh",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ node('ibm-jenkins-slave-dind') {
   def artifactsForUploadAndInstallation = [
     "scripts/create-security-defn.sh",
     "scripts/zowe-xmem-apf.sh",
+    "scripts/zowe-xmem-check-if-sms.sh",
     "scripts/temp-fixes-before-install.sh",
     "scripts/temp-fixes-after-install.sh",
     "scripts/temp-fixes-after-started.sh",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -470,11 +470,11 @@ EOF"""
 
           // pull job log
           sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWESECUR' -o '${USERNAME}' -a file-contents"
-          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWES*STC' -o ZWES*USR -a file-contents"
+          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWES*' -o 'ZWES*' -a file-contents"
         } catch (e) {
           // pull job log
           sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWESECUR' -o '${USERNAME}' -a file-contents"
-          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWES*STC' -o 'ZWES*USR' -a file-contents"
+          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWES*' -o 'ZWES*' -a file-contents"
           throw e
         } // end of try/catch
       } // end of withCredentials

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -471,11 +471,11 @@ EOF"""
 
           // pull job log
           sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWESECUR' -o '${USERNAME}' -a file-contents"
-          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWES*' -o 'ZWES*' -a file-contents"
+          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWE*' -o 'ZWES*' -a file-contents"
         } catch (e) {
           // pull job log
           sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWESECUR' -o '${USERNAME}' -a file-contents"
-          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWES*' -o 'ZWES*' -a file-contents"
+          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWE*' -o 'ZWES*' -a file-contents"
           throw e
         } // end of try/catch
       } // end of withCredentials

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -469,7 +469,8 @@ EOF"""
           } // end of timeout - post install verify script
 
           // pull job log
-          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWES*STC' -o ZWESVUSR -a file-contents"
+          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWESECUR' -o '${USERNAME}' -a file-contents"
+          sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWES*STC' -o ZWES*USR -a file-contents"
         } catch (e) {
           // pull job log
           sh "./scripts/show-job-logs.sh -d -H '${SSH_HOST}' -P '${zOsmfPort}' -u '${USERNAME}' -p '${PASSWORD}' -n 'ZWESECUR' -o '${USERNAME}' -a file-contents"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ node('ibm-jenkins-slave-dind') {
 
   def artifactsForUploadAndInstallation = [
     "scripts/create-security-defn.sh",
+    "scripts/zowe-xmem-apf.sh",
     "scripts/temp-fixes-before-install.sh",
     "scripts/temp-fixes-after-install.sh",
     "scripts/temp-fixes-after-started.sh",

--- a/scripts/create-security-defn.sh
+++ b/scripts/create-security-defn.sh
@@ -128,8 +128,8 @@ echo "$SCRIPT Tailor ZWESECUR.jcl for execution in our test environment"
 echo "$SCRIPT ZWESECUR.jcl obtained from"
 if [[ "$CI_IS_SMPE" = "yes" ]]
 then
-    echo "$SCRIPT   $DATA_SET_PREFIX(ZWESECUR)"
-    cp "//'$DATA_SET_PREFIX(ZWESECUR)'" $CIZT_TMP/ZWESECUR.raw.jcl
+    echo "$SCRIPT   $DATA_SET_PREFIX.SZWESAMP(ZWESECUR)"
+    cp "//'$DATA_SET_PREFIX.SZWESAMP(ZWESECUR)'" $CIZT_TMP/ZWESECUR.raw.jcl
 else
     echo "$SCRIPT   $FULL_EXTRACTED_ZOWE_FOLDER/files/jcl/ZWESECUR.jcl"
     cp $FULL_EXTRACTED_ZOWE_FOLDER/files/jcl/ZWESECUR.jcl $CIZT_TMP/ZWESECUR.raw.jcl

--- a/scripts/create-security-defn.sh
+++ b/scripts/create-security-defn.sh
@@ -125,15 +125,8 @@ function runJob {
 }
 
 echo "$SCRIPT Tailor ZWESECUR.jcl for execution in our test environment"
-echo "$SCRIPT ZWESECUR.jcl obtained from"
-if [[ "$CI_IS_SMPE" = "yes" ]]
-then
-    echo "$SCRIPT   $DATA_SET_PREFIX.SZWESAMP(ZWESECUR)"
-    cp "//'$DATA_SET_PREFIX.SZWESAMP(ZWESECUR)'" $CIZT_TMP/ZWESECUR.raw.jcl
-else
-    echo "$SCRIPT   $FULL_EXTRACTED_ZOWE_FOLDER/files/jcl/ZWESECUR.jcl"
-    cp $FULL_EXTRACTED_ZOWE_FOLDER/files/jcl/ZWESECUR.jcl $CIZT_TMP/ZWESECUR.raw.jcl
-fi
+
+cp "//'$DATA_SET_PREFIX.SZWESAMP(ZWESECUR)'" $CIZT_TMP/ZWESECUR.raw.jcl
 
 echo "check ZWESECUR.jcl start ==="
 head $CIZT_TMP/ZWESECUR.raw.jcl

--- a/scripts/create-security-defn.sh
+++ b/scripts/create-security-defn.sh
@@ -125,7 +125,7 @@ function runJob {
 }
 
 echo "$SCRIPT Tailor ZWESECUR.jcl for execution in our test environment"
-
+echo "$SCRIPT Obtain ZWESECUR.jcl from $DATA_SET_PREFIX.SZWESAMP(ZWESECUR)"
 cp "//'$DATA_SET_PREFIX.SZWESAMP(ZWESECUR)'" $CIZT_TMP/ZWESECUR.raw.jcl
 
 echo "check ZWESECUR.jcl start ==="

--- a/scripts/create-security-defn.sh
+++ b/scripts/create-security-defn.sh
@@ -125,11 +125,20 @@ function runJob {
 }
 
 echo "$SCRIPT Tailor ZWESECUR.jcl for execution in our test environment"
-cd $FULL_EXTRACTED_ZOWE_FOLDER/files/jcl
+echo "$SCRIPT ZWESECUR.jcl obtained from"
+if [[ "$CI_IS_SMPE" = "yes" ]]
+then
+    echo "$SCRIPT   $DATA_SET_PREFIX(ZWESECUR)"
+    cp "//'$DATA_SET_PREFIX(ZWESECUR)'" $CIZT_TMP/ZWESECUR.raw.jcl
+else
+    echo "$SCRIPT   $FULL_EXTRACTED_ZOWE_FOLDER/files/jcl/ZWESECUR.jcl"
+    cp $FULL_EXTRACTED_ZOWE_FOLDER/files/jcl/ZWESECUR.jcl $CIZT_TMP/ZWESECUR.raw.jcl
+fi
+
 echo "check ZWESECUR.jcl start ==="
-head ZWESECUR.jcl
+head $CIZT_TMP/ZWESECUR.raw.jcl
 echo "check ZWESECUR.jcl end   ==="
-# Nullify ADDGROUP, ALTGROUP and ADDUSER
+# Nullify ADDGROUP, ALTGROUP and ADDUSER for pipeline environment because these exist there already
 sed \
     -e "s+ADMINGRP=ZWEADMIN+ADMINGRP=${CIZT_ZSS_STC_GROUP}+" \
     -e "s+ZOWEUSER=ZWESVUSR+ZOWEUSER=$CIZT_ZSS_ZOWE_USER+" \
@@ -140,7 +149,7 @@ sed \
     -e "s+ADDGROUP+NOADDGROUP+" \
     -e "s+ALTGROUP+NOALTGROUP+" \
     -e "s+ADDUSER+NOADDUSER+" \
-    ZWESECUR.jcl > $CIZT_TMP/ZWESECUR.jcl
+    $CIZT_TMP/ZWESECUR.raw.jcl > $CIZT_TMP/ZWESECUR.jcl
     
 echo "check tailoring start ==="
 grep -e "^// *SET " \

--- a/scripts/create-security-defn.sh
+++ b/scripts/create-security-defn.sh
@@ -128,9 +128,9 @@ echo "$SCRIPT Tailor ZWESECUR.jcl for execution in our test environment"
 echo "$SCRIPT Obtain ZWESECUR.jcl from $DATA_SET_PREFIX.SZWESAMP(ZWESECUR)"
 cp "//'$DATA_SET_PREFIX.SZWESAMP(ZWESECUR)'" $CIZT_TMP/ZWESECUR.raw.jcl
 
-echo "check ZWESECUR.jcl start ==="
+echo "check ZWESECUR.jcl first 10 lines of content ==="
 head $CIZT_TMP/ZWESECUR.raw.jcl
-echo "check ZWESECUR.jcl end   ==="
+echo "check ZWESECUR.jcl end   of content ==="
 # Nullify ADDGROUP, ALTGROUP and ADDUSER for pipeline environment because these exist there already
 sed \
     -e "s+ADMINGRP=ZWEADMIN+ADMINGRP=${CIZT_ZSS_STC_GROUP}+" \

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -255,6 +255,9 @@ fi
 if [ -f "create-security-defn.sh" ]; then
   ensure_script_encoding create-security-defn.sh
 fi
+if [ -f "zowe-xmem-apf.sh" ]; then
+  ensure_script_encoding zowe-xmem-apf.sh
+fi
 if [ -f "uninstall-zowe.sh" ]; then
   ensure_script_encoding uninstall-zowe.sh
 fi

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -261,9 +261,6 @@ fi
 if [ -f "install-SMPE-PAX.sh" ]; then
   ensure_script_encoding install-SMPE-PAX.sh
 fi
-if [ -f "install-xmem-server.sh" ]; then
-  ensure_script_encoding install-xmem-server.sh
-fi
 if [ -f "opercmd" ]; then
   ensure_script_encoding opercmd "parse var command opercmd"
 fi
@@ -510,14 +507,9 @@ fi
 
 #TODO - refactor
 echo "[${SCRIPT_NAME}] Starting installing xmem server ..."
-if [[ "$CI_IS_SMPE" = "yes" ]]; then
-  echo "[${SCRIPT_NAME}] creating APF settings of ${CIZT_ZSS_LOADLIB_DS_NAME}(${CIZT_ZSS_LOADLIB_MEMBER}) ..."
-    (exec "${CIZT_INSTALL_DIR}/opercmd" "SETPROG APF,ADD,DSNAME=${CIZT_ZSS_LOADLIB_DS_NAME},VOLUME=VPMVSC")
 
-else
-  cd $FULL_EXTRACTED_ZOWE_FOLDER/install
-  ${CIZT_INSTALL_DIR}/install-xmem-server.sh
-fi
+echo "[${SCRIPT_NAME}] creating APF settings of ${CIZT_ZSS_LOADLIB_DS_NAME}(${CIZT_ZSS_LOADLIB_MEMBER}) ..."
+    (exec "${CIZT_INSTALL_DIR}/opercmd" "SETPROG APF,ADD,DSNAME=${CIZT_ZSS_LOADLIB_DS_NAME},VOLUME=VPMVSC")
 
 echo "Setting up certificate..."
 # Create a copy of the default environment

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -511,9 +511,9 @@ fi
 #TODO - refactor
 echo "[${SCRIPT_NAME}] Starting installing xmem server ..."
 if [[ "$CI_IS_SMPE" = "yes" ]]; then
-  :
-  # cd ${CIZT_SMPE_PATH_PREFIX}${CIZT_SMPE_PATH_DEFAULT}/xmem-server
-  # ${CIZT_INSTALL_DIR}/install-xmem-server.sh
+  echo "[${SCRIPT_NAME}] creating APF settings of ${CIZT_ZSS_LOADLIB_DS_NAME}(${CIZT_ZSS_LOADLIB_MEMBER}) ..."
+    (exec "${CIZT_INSTALL_DIR}/opercmd" "SETPROG APF,ADD,DSNAME=${CIZT_ZSS_LOADLIB_DS_NAME},VOLUME=VPMVSC")
+
 else
   cd $FULL_EXTRACTED_ZOWE_FOLDER/install
   ${CIZT_INSTALL_DIR}/install-xmem-server.sh
@@ -598,6 +598,7 @@ if [ "$CI_SKIP_TEMP_FIXES" != "yes" ]; then
     fi
   fi
 fi
+
 
 # start cross memory server
 echo "[${SCRIPT_NAME}] start ZWESISTC ..."

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -509,7 +509,26 @@ fi
 echo "[${SCRIPT_NAME}] Starting installing xmem server ..."
 
 echo "[${SCRIPT_NAME}] creating APF settings of ${CIZT_ZSS_LOADLIB_DS_NAME}(${CIZT_ZSS_LOADLIB_MEMBER}) ..."
-    (exec "${CIZT_INSTALL_DIR}/opercmd" "SETPROG APF,ADD,DSNAME=${CIZT_ZSS_LOADLIB_DS_NAME},VOLUME=VPMVSC")
+    # (exec "${CIZT_INSTALL_DIR}/opercmd" "SETPROG APF,ADD,DSNAME=${CIZT_ZSS_LOADLIB_DS_NAME},VOLUME=VPMVSC")
+
+echo "calling zowe-xmem-apf.sh with"
+echo "  opercmd       ${CIZT_INSTALL_DIR}/opercmd"
+echo "  zss loadlib   ${CIZT_ZSS_LOADLIB_DS_NAME}"
+
+RUN_SCRIPT=./zowe-xmem-apf.sh
+echo "[${SCRIPT_NAME}] calling $RUN_SCRIPT from directory $(pwd)"
+run_script_with_timeout "$RUN_SCRIPT \
+  ${CIZT_INSTALL_DIR}/opercmd \
+  ${CIZT_ZSS_LOADLIB_DS_NAME}" 1800
+EXIT_CODE=$?
+if [[ "$EXIT_CODE" != "0" ]]; then
+  echo "[${SCRIPT_NAME}][error] ${RUN_SCRIPT} failed with exit code $EXIT_CODE."
+  echo
+  exit 1
+else
+  echo "[${SCRIPT_NAME}] ${RUN_SCRIPT} succeeds."
+  echo
+fi
 
 echo "Setting up certificate..."
 # Create a copy of the default environment

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -516,7 +516,7 @@ echo "  opercmd       ${CIZT_INSTALL_DIR}/opercmd"
 echo "  zss loadlib   ${CIZT_ZSS_LOADLIB_DS_NAME}"
 
 RUN_SCRIPT=./zowe-xmem-apf.sh
-cd $CIZT_ZOWE_ROOT_DIR/scripts/utils
+cd $CIZT_ZOWE_ROOT_DIR/scripts/zss
 echo "[${SCRIPT_NAME}] calling $RUN_SCRIPT from directory $(pwd)"
 run_script_with_timeout "$RUN_SCRIPT \
   ${CIZT_INSTALL_DIR}/opercmd \

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -511,8 +511,9 @@ fi
 #TODO - refactor
 echo "[${SCRIPT_NAME}] Starting installing xmem server ..."
 if [[ "$CI_IS_SMPE" = "yes" ]]; then
-  cd ${CIZT_SMPE_PATH_PREFIX}${CIZT_SMPE_PATH_DEFAULT}/xmem-server
-  ${CIZT_INSTALL_DIR}/install-xmem-server.sh
+  :
+  # cd ${CIZT_SMPE_PATH_PREFIX}${CIZT_SMPE_PATH_DEFAULT}/xmem-server
+  # ${CIZT_INSTALL_DIR}/install-xmem-server.sh
 else
   cd $FULL_EXTRACTED_ZOWE_FOLDER/install
   ${CIZT_INSTALL_DIR}/install-xmem-server.sh

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -352,23 +352,6 @@ if [[ "$CI_IS_SMPE" = "yes" ]]; then
     fi
   fi
 
-# # EXTRACTED_ZOWE_FOLDER is also needed for SMP/E ...
-# temporary workaround ...
-# 17:32:23 /ZOWE/zowe-installs/a:
-# 17:32:23 zowe-1.8.0
-# 17:32:23 /ZOWE/zowe-installs/a/zowe-1.8.0/files/jcl:
-# 17:32:23 ZWESECUR.jcl  ZWESVSTC.jcl
-  # export FULL_EXTRACTED_ZOWE_FOLDER=$CIZT_INSTALL_DIR/a
-  # EXTRACTED_FILES=$(ls -1 $CIZT_INSTALL_DIR/a | wc -l | awk '{print $1}')
-  # HAS_EXTRA_ZOWE_FOLDER=0
-  # if [ "$EXTRACTED_FILES" = "1" ]; then
-  #   HAS_EXTRA_ZOWE_FOLDER=1
-  #   EXTRACTED_ZOWE_FOLDER=$(ls -1 $CIZT_INSTALL_DIR/a)
-  #   export FULL_EXTRACTED_ZOWE_FOLDER=$CIZT_INSTALL_DIR/a/$EXTRACTED_ZOWE_FOLDER
-  # fi
-  # echo     HAS_EXTRA_ZOWE_FOLDER=$HAS_EXTRA_ZOWE_FOLDER
-
-
   echo "[${SCRIPT_NAME}] all SMP/e install is done."
   echo
 else #not SMPE

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -495,9 +495,9 @@ else
   echo
 fi
 
-echo "[${SCRIPT_NAME}] ${CIZT_ZSS_PROCLIB_DS_NAME}(ZWESISTC) ==== start"
+echo "[${SCRIPT_NAME}] ${CIZT_ZSS_PROCLIB_DS_NAME}(ZWESISTC) ==== start of contents"
 cat "//'${CIZT_ZSS_PROCLIB_DS_NAME}(ZWESISTC)'"
-echo "[${SCRIPT_NAME}] ${CIZT_ZSS_PROCLIB_DS_NAME}(ZWESISTC) ==== end"
+echo "[${SCRIPT_NAME}] ${CIZT_ZSS_PROCLIB_DS_NAME}(ZWESISTC) ==== end of contents"
 
 # Run security job to create the SAF definitions for Zowe
 cd $CIZT_INSTALL_DIR
@@ -515,7 +515,6 @@ fi
 echo "[${SCRIPT_NAME}] Starting installing xmem server ..."
 
 echo "[${SCRIPT_NAME}] creating APF settings of ${CIZT_ZSS_LOADLIB_DS_NAME}(${CIZT_ZSS_LOADLIB_MEMBER}) ..."
-    # (exec "${CIZT_INSTALL_DIR}/opercmd" "SETPROG APF,ADD,DSNAME=${CIZT_ZSS_LOADLIB_DS_NAME},VOLUME=VPMVSC")
 
 echo "calling zowe-xmem-apf.sh with"
 echo "  opercmd       ${CIZT_INSTALL_DIR}/opercmd"
@@ -586,22 +585,6 @@ if [ ! -f ${CIZT_ZOWE_USER_DIR}"/bin/zowe-start.sh" ]; then
   echo "[${SCRIPT_NAME}][error] installation is not successfully, cannot find zowe-start.sh."
   exit 1
 fi
-
-# execute scripts/configure/zowe-config-stc.sh TODO - replace with ZWESECUR
-echo "[${SCRIPT_NAME}] executing scripts/configure/zowe-config-stc.sh ..."
-if [ -f "${CIZT_ZOWE_ROOT_DIR}/scripts/configure/zowe-config-stc.sh" ]; then
-  RUN_SCRIPT="${CIZT_ZOWE_ROOT_DIR}/scripts/configure/zowe-config-stc.sh"
-  if [ -f "$RUN_SCRIPT" ]; then
-    run_script_with_timeout "${RUN_SCRIPT}" 300
-    EXIT_CODE=$?
-    if [[ "$EXIT_CODE" != "0" ]]; then
-      echo "[${SCRIPT_NAME}][warning] ${RUN_SCRIPT} failed with exit code ${EXIT_CODE}."
-    fi
-  fi
-else
-  echo "[${SCRIPT_NAME}][warning] not found."
-fi
-echo
 
 # run temp fixes
 if [ "$CI_SKIP_TEMP_FIXES" != "yes" ]; then

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -313,9 +313,9 @@ if [[ "$CI_UNINSTALL" = "yes" ]]; then
   fi
 fi
 
-DATA_SET_PREFIX=$USER.ZWE
+export DATA_SET_PREFIX=$USER.ZWE
 if [[ "$CI_IS_SMPE" = "yes" ]]; then
-  DATA_SET_PREFIX=$USER.SMPE
+  export DATA_SET_PREFIX=$USER.SMPE
 fi
 
 rm -fr ${CIZT_INSTALL_DIR}/extracted && mkdir -p ${CIZT_INSTALL_DIR}/extracted

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -517,6 +517,8 @@ echo "  zss loadlib   ${CIZT_ZSS_LOADLIB_DS_NAME}"
 
 RUN_SCRIPT=./zowe-xmem-apf.sh
 cd $CIZT_INSTALL_DIR
+ls -l     $RUN_SCRIPT
+chmod a+x $RUN_SCRIPT
 echo "[${SCRIPT_NAME}] calling $RUN_SCRIPT from directory $(pwd)"
 run_script_with_timeout "$RUN_SCRIPT \
   ${CIZT_INSTALL_DIR}/opercmd \

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -516,7 +516,7 @@ echo "  opercmd       ${CIZT_INSTALL_DIR}/opercmd"
 echo "  zss loadlib   ${CIZT_ZSS_LOADLIB_DS_NAME}"
 
 RUN_SCRIPT=./zowe-xmem-apf.sh
-cd $CIZT_ZOWE_ROOT_DIR/scripts/zss
+cd $CIZT_INSTALL_DIR
 echo "[${SCRIPT_NAME}] calling $RUN_SCRIPT from directory $(pwd)"
 run_script_with_timeout "$RUN_SCRIPT \
   ${CIZT_INSTALL_DIR}/opercmd \

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -358,15 +358,15 @@ if [[ "$CI_IS_SMPE" = "yes" ]]; then
 # 17:32:23 zowe-1.8.0
 # 17:32:23 /ZOWE/zowe-installs/a/zowe-1.8.0/files/jcl:
 # 17:32:23 ZWESECUR.jcl  ZWESVSTC.jcl
-  export FULL_EXTRACTED_ZOWE_FOLDER=$CIZT_INSTALL_DIR/a
-  EXTRACTED_FILES=$(ls -1 $CIZT_INSTALL_DIR/a | wc -l | awk '{print $1}')
-  HAS_EXTRA_ZOWE_FOLDER=0
-  if [ "$EXTRACTED_FILES" = "1" ]; then
-    HAS_EXTRA_ZOWE_FOLDER=1
-    EXTRACTED_ZOWE_FOLDER=$(ls -1 $CIZT_INSTALL_DIR/a)
-    export FULL_EXTRACTED_ZOWE_FOLDER=$CIZT_INSTALL_DIR/a/$EXTRACTED_ZOWE_FOLDER
-  fi
-  echo     HAS_EXTRA_ZOWE_FOLDER=$HAS_EXTRA_ZOWE_FOLDER
+  # export FULL_EXTRACTED_ZOWE_FOLDER=$CIZT_INSTALL_DIR/a
+  # EXTRACTED_FILES=$(ls -1 $CIZT_INSTALL_DIR/a | wc -l | awk '{print $1}')
+  # HAS_EXTRA_ZOWE_FOLDER=0
+  # if [ "$EXTRACTED_FILES" = "1" ]; then
+  #   HAS_EXTRA_ZOWE_FOLDER=1
+  #   EXTRACTED_ZOWE_FOLDER=$(ls -1 $CIZT_INSTALL_DIR/a)
+  #   export FULL_EXTRACTED_ZOWE_FOLDER=$CIZT_INSTALL_DIR/a/$EXTRACTED_ZOWE_FOLDER
+  # fi
+  # echo     HAS_EXTRA_ZOWE_FOLDER=$HAS_EXTRA_ZOWE_FOLDER
 
 
   echo "[${SCRIPT_NAME}] all SMP/e install is done."
@@ -523,8 +523,6 @@ echo "  zss loadlib   ${CIZT_ZSS_LOADLIB_DS_NAME}"
 
 RUN_SCRIPT=./zowe-xmem-apf.sh
 cd $CIZT_INSTALL_DIR
-ls -l     $RUN_SCRIPT
-chmod a+x $RUN_SCRIPT
 echo "[${SCRIPT_NAME}] calling $RUN_SCRIPT from directory $(pwd)"
 run_script_with_timeout "$RUN_SCRIPT \
   ${CIZT_INSTALL_DIR}/opercmd \

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -492,9 +492,9 @@ else
   echo
 fi
 
-echo "[${SCRIPT_NAME}] VENDOR.PROCLIB(ZWESISTC) ==== start"
-cat "//'VENDOR.PROCLIB(ZWESISTC)'"
-echo "[${SCRIPT_NAME}] VENDOR.PROCLIB(ZWESISTC) ==== end"
+echo "[${SCRIPT_NAME}] ${CIZT_ZSS_PROCLIB_DS_NAME}(ZWESISTC) ==== start"
+cat "//'${CIZT_ZSS_PROCLIB_DS_NAME}(ZWESISTC)'"
+echo "[${SCRIPT_NAME}] ${CIZT_ZSS_PROCLIB_DS_NAME}(ZWESISTC) ==== end"
 
 # Run security job to create the SAF definitions for Zowe
 cd $CIZT_INSTALL_DIR

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -258,6 +258,9 @@ fi
 if [ -f "zowe-xmem-apf.sh" ]; then
   ensure_script_encoding zowe-xmem-apf.sh
 fi
+if [ -f "zowe-xmem-check-if-sms.sh" ]; then
+  ensure_script_encoding zowe-xmem-check-if-sms.sh
+fi
 if [ -f "uninstall-zowe.sh" ]; then
   ensure_script_encoding uninstall-zowe.sh
 fi

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -516,6 +516,7 @@ echo "  opercmd       ${CIZT_INSTALL_DIR}/opercmd"
 echo "  zss loadlib   ${CIZT_ZSS_LOADLIB_DS_NAME}"
 
 RUN_SCRIPT=./zowe-xmem-apf.sh
+cd $CIZT_ZOWE_ROOT_DIR/scripts/utils
 echo "[${SCRIPT_NAME}] calling $RUN_SCRIPT from directory $(pwd)"
 run_script_with_timeout "$RUN_SCRIPT \
   ${CIZT_INSTALL_DIR}/opercmd \

--- a/scripts/install-zowe.sh
+++ b/scripts/install-zowe.sh
@@ -492,6 +492,9 @@ else
   echo
 fi
 
+echo "[${SCRIPT_NAME}] VENDOR.PROCLIB(ZWESISTC) ==== start"
+cat "//'VENDOR.PROCLIB(ZWESISTC)'"
+echo "[${SCRIPT_NAME}] VENDOR.PROCLIB(ZWESISTC) ==== end"
 
 # Run security job to create the SAF definitions for Zowe
 cd $CIZT_INSTALL_DIR

--- a/scripts/uninstall-zowe.sh
+++ b/scripts/uninstall-zowe.sh
@@ -182,17 +182,19 @@ fi
 echo
 
 ################################################################################
-echo "[${SCRIPT_NAME}] Display zowe user and group ..."
-wrap_call tsocmd 'LISTGRP  ZWEADMIN'
-wrap_call tsocmd 'LISTGRP  IZUADMIN'
+# --- The code below can be un-commented for debugging
+# echo "[${SCRIPT_NAME}] Display zowe user and group ..."
+# wrap_call tsocmd 'LISTGRP  ZWEADMIN'
+# wrap_call tsocmd 'LISTGRP  IZUADMIN'
 
-wrap_call tsocmd 'LISTUSER ZWESVUSR OMVS'
-wrap_call tsocmd 'LISTUSER ZWESIUSR OMVS'
-wrap_call tsocmd 'LISTUSER ZOWEAD3  OMVS'
-wrap_call tsocmd 'LISTUSER '
+# wrap_call tsocmd 'LISTUSER ZWESVUSR OMVS'
+# wrap_call tsocmd 'LISTUSER ZWESIUSR OMVS'
+# wrap_call tsocmd 'LISTUSER ZOWEAD3  OMVS'
+# wrap_call tsocmd 'LISTUSER '
 
-echo "[${SCRIPT_NAME}] Display ZWESVUSR USS user and group ..."
-id ZWESVUSR
+# echo "[${SCRIPT_NAME}] Display ZWESVUSR USS user and group ..."
+# id ZWESVUSR
+# --- The code above can be un-commented for debugging
 
 # delete started tasks
 echo "[${SCRIPT_NAME}] deleting started tasks ..."

--- a/scripts/zowe-xmem-apf.sh
+++ b/scripts/zowe-xmem-apf.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+BASEDIR=$(dirname "$0")
+OPERCMD=$1
+loadlib=$2
+
+echo "APF-authorize loadlib ${loadlib}"
+
+isSMS=true
+sh $BASEDIR/zowe-xmem-check-if-sms.sh ${loadlib}
+checkRC=$?
+if [[ $checkRC -eq 1 ]]; then
+  isSMS=true
+elif [[ $checkRC -eq 0 ]]; then
+  isSMS=false
+else
+  echo "Warning:  SMS check failed, please APF-authorize the dataset manually if needed"
+fi
+
+if $isSMS ; then
+
+  cmdout="$(${OPERCMD} "SETPROG APF,ADD,DSNAME=${loadlib},SMS" 2>&1)"
+
+else
+
+  cmdout="$(tsocmd "listds '${loadlib}'" 2>&1)"
+  if [[ $? -ne 0 ]]; then
+    echo "Error:  LISTDS failed"
+    echo "$cmdout"
+    exit 8
+  fi
+
+  volume="$(echo $cmdout | sed -n "s/.*--VOLUMES--[\s]*\([^\s]\)[\s]*/\1/p")"
+  if [[ -z "$volume" ]]; then
+    echo "Error:  volume not found"
+    echo "$cmdout"
+    exit 8
+  fi
+
+  cmdout="$(${OPERCMD} "SETPROG APF,ADD,DSNAME=${loadlib},VOLUME=${volume}" 2>&1)"
+
+fi
+
+if echo $cmdout | grep "CSV410I" 1>/dev/null; then
+  echo "Info:  dataset ${loadlib} has been added to APF list"
+  exit 0
+else
+  echo "Error:  dataset ${loadlib} has not been added to APF list"
+  echo "$cmdout"
+  exit 8
+fi
+

--- a/scripts/zowe-xmem-check-if-sms.sh
+++ b/scripts/zowe-xmem-check-if-sms.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Copyright Contributors to the Zowe Project.
+
+BASEDIR=$(dirname "$0")
+dsn=$1
+
+echo "Check if dataset ${dsn} is SMS-managed"
+
+cmdout="$(tsocmd "listds '${dsn}' label" 2>&1)"
+if [[ $? -ne 0 ]]; then
+  echo "Error:  LISTDS failed"
+  echo "$cmdout"
+  exit 8
+fi
+
+dscb="$(echo $cmdout | sed -n "s/.*--FORMAT 1 DSCB-- \(.*\)/\1/p")"
+if [[ -z "$dscb" ]]; then
+  echo "Error:  DSCB1 not found"
+  echo "$cmdout"
+  exit 8
+fi
+
+# DS1SMSFG - System managed storage indicators
+ds1smsfg="$(echo $dscb | sed -n "s/.\{77\}\(.\{2\}\).*/\1/p")"
+if [[ -z "ds1smsfg" ]]; then
+  echo "Error:  DS1SMSFG not found in DSCB1"
+  echo "$cmdout"
+  exit 8
+fi
+
+# DS1SMSDS (0x80) - System managed data set (must be set)
+ds1smsfg_masked="$((0x$ds1smsfg & 0x80))"
+
+# If the masked value is 0x80 (128), the dataset is SMS-managed
+if [[ $ds1smsfg_masked == "128" ]]; then
+  echo "Info:  dataset ${dsn} is SMS-managed"
+  exit 1
+else
+  echo "Info:  dataset ${dsn} is not SMS-managed"
+  echo "$cmdout"
+  exit 0
+fi
+


### PR DESCRIPTION
This PR switches to using ZWESECUR for SAF settings.  

It removes calls to `install-xmem-server.sh`.  

It uses the helper script `zowe-install-xmem.sh` instead, which is provided for customer use.

APF setting is done in a private helper script `zowe-xmem-apf.sh` for use exclusively in the pipeline because it requires SDSF.  